### PR TITLE
make report get full comment work

### DIFF
--- a/repltalk/__init__.py
+++ b/repltalk/__init__.py
@@ -439,7 +439,10 @@ class Comment():
 		if not r:
 			raise AlreadyReported('This comment has already been reported by this account.')
 		return r
-
+	
+	async def get_full_comment(self):
+		return await self.client.get_comment(self.id)
+	
 	def __hash__(self):
 		return hash((self.id, self.content, self.votes, self.replies))
 


### PR DESCRIPTION
Reports error out saying Comment has no attribute get_full_comment, so how it gets a normal comment not lazy comment, so this makes Comment allow get_full_comment