### PR TITLE
Fix ReportsList

### DIFF
--- a/repltalk/__init__.py
+++ b/repltalk/__init__.py
@@ -169,12 +169,11 @@ class LazyReport:
 
 class ReportList():
 	__slots__ = (
-		'client', 'refresh', 'resolved', 'i'
+		'client', 'refresh', 'resolved', 'reports', 'i'
 	)
-	reports = []
 
 	def __init__(self, client, data):
-
+		self.reports = []
 		for r in data:
 			try:
 				self.reports.append(Report(client, r))


### PR DESCRIPTION
Currently All reportsList's instances have the same ammount of reports, and calling get_reports twice they will both have all reports repeated. This changes it to a per instance var not per class

Closes #16