### PR TITLE
fix get_comment()

### DIFF
--- a/repltalk/__init__.py
+++ b/repltalk/__init__.py
@@ -1204,7 +1204,7 @@ class Client():
 		return await self.perform_graphql(
 			'comment',
 			Queries.get_comment,
-			id=96061
+			id=id
 		)
 
 	async def get_comment(self, id):


### PR DESCRIPTION
get_comment() used to always return the same comment, because for some reason an id was hard coded into the _get_comment() function.